### PR TITLE
Update to run on newer versions of Mutagen and Synthesis

### DIFF
--- a/GrassFPS/Program.cs
+++ b/GrassFPS/Program.cs
@@ -1,6 +1,5 @@
 using GrassFPS.Settings;
 using Mutagen.Bethesda;
-using Mutagen.Bethesda.Fallout4;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Synthesis;
 using System;


### PR DESCRIPTION
Using 0.50.2 Mutagen and 0.34.0 Synthesis will throw out an error during patch compilation on line 3 of program.cs.

Removing the line fixed the problem. This patch is for Skyrim anyway, so using Fallout4 is probably not necessary anyways.

I have checked the generated ```synthesis.esp``` and confirmed the patch seems to be working as intended, patching all Grass records in the load order.

Using the original versions of Mutagen and Synthesis (```Match``` options with the GUI) appears to be a no go and throw out errors on Skyrim GOG.