### PR TITLE
API bump

### DIFF
--- a/GrassFPS/GrassFPS.csproj
+++ b/GrassFPS/GrassFPS.csproj
@@ -1,22 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<AllowUnsafeBlocks>False</AllowUnsafeBlocks>
 		<PlatformTarget>x64</PlatformTarget>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>portable</DebugType>
-	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.39.6" />
-		<PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.24.0" />
+		<PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.51.0" />
+		<PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.35.0" />
 	</ItemGroup>
 </Project>

--- a/GrassFPS/Program.cs
+++ b/GrassFPS/Program.cs
@@ -1,6 +1,5 @@
 using GrassFPS.Settings;
 using Mutagen.Bethesda;
-using Mutagen.Bethesda.Fallout4;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Synthesis;
 using System;


### PR DESCRIPTION
Unnecessary import was causing build break since synthesis' libraries no longer import all games by default